### PR TITLE
fix: corrige ordem dos jogadores ao recomeçar partida

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,163 @@
+# Documentação técnica — marcador-general
+
+Documentação voltada para desenvolvimento: arquitetura, fluxo de estado, como rodar o
+projeto e o que planejamos implementar. Para as **regras do jogo** e o "como jogar",
+veja o [README.md](./README.md).
+
+## Stack
+
+- **React 18** (componentes funcionais + hooks) — sem gerenciador de estado externo.
+- **Webpack 5** + **Babel** (`@babel/preset-env`, `@babel/preset-react`) como bundler/transpiler.
+- **Sass (SCSS)** para estilos, carregado via `style-loader` → `css-loader` → `sass-loader`.
+- **Capacitor 6** para empacotar o app web como app nativo (Android/iOS).
+- **Prettier** para formatação.
+
+Não há backend nem persistência: todo o estado vive em memória enquanto a partida acontece.
+
+## Como rodar
+
+```bash
+npm install        # instala dependências
+npm start          # sobe o webpack-dev-server e abre no navegador
+npm run build      # build de produção em dist/
+npm run format     # roda o Prettier em src/**
+```
+
+O build gera `dist/`, que é o `webDir` consumido pelo Capacitor (ver `capacitor.config.ts`)
+para empacotar as versões mobile.
+
+## Estrutura de pastas
+
+```
+src/
+  index.js               # ponto de entrada; monta <App /> no DOM
+  index.html             # template do HtmlWebpackPlugin
+  App.jsx                # raiz: alterna entre cadastro e partida; header + reset
+  components/
+    CadastroJogadores.jsx  # tela inicial: nº de jogadores + nomes
+    Marcador.jsx           # coração do jogo: estado da partida, turnos, histórico
+    Tabela.jsx             # grade de categorias × pontuações clicáveis
+    FimDeJogo.jsx          # ranking final, emojis, recomeçar/nova partida
+  styles/                # SCSS por componente + parciais (_variaveis, _botoes, _flex...)
+  assets/                # logo, ícones (svg), favicon
+```
+
+## Arquitetura e fluxo de estado
+
+O app tem essencialmente **dois modos**, controlados por `App.jsx` via `partidaIniciada`:
+
+1. **Cadastro** (`CadastroJogadores`) → quando `partidaIniciada === false`.
+2. **Partida** (`Marcador`) → quando `partidaIniciada === true`.
+
+### `App.jsx`
+
+- `partidaIniciada` (bool) e `nomes` (array de jogadores).
+- `handleGameStart(jogadores)`: recebe a lista pronta do cadastro e entra na partida.
+- `handleGameReset()`: confirma via `confirm()` e volta ao cadastro (**nova partida**).
+
+### `CadastroJogadores.jsx`
+
+- Controla `numJogadores` (1–20, default 2) e `nomes[]`.
+- Botões `+`/`-` e input numérico ajustam a quantidade; `useEffect` liga/desliga os
+  botões nos limites (1 e 20).
+- `handleSalvar()` monta o array de jogadores no formato canônico e chama `onGameStart`.
+
+**Formato do jogador** (a "fonte da verdade" do placar):
+
+```js
+{
+  nome: 'Fulano',
+  pontos: {
+    ones, twos, threes, fours, fives, sixes,   // categorias numéricas
+    fullHouse, straight, quadra, general, generalDeMao, // especiais
+    total: 0,
+  }
+}
+```
+
+Cada categoria começa `undefined` (= ainda não preenchida) e recebe um número ao ser
+marcada. `total` acumula a soma.
+
+### `Marcador.jsx` (núcleo)
+
+Estado principal:
+
+| Estado             | Papel                                                              |
+| ------------------ | ----------------------------------------------------------------- |
+| `jogadores`        | array de jogadores com seus `pontos` (fonte da verdade do placar) |
+| `jogadorAtual`     | índice do jogador da vez                                           |
+| `marcouPonto`      | se o jogador já escolheu uma célula na rodada atual               |
+| `gameOver`         | dispara a tela de fim de jogo                                     |
+| `listaNomes`       | ranking final calculado                                           |
+| `voltarJogada`     | última célula marcada `{ jogadorAtual, obj, pontos }` (para troca)|
+| `historicoJogadas` | pilha de jogadas **confirmadas** (para o "voltar jogada")         |
+
+Fluxo de uma jogada:
+
+1. **`setPonto(jogadorAtual, pontos, obj)`** (disparado pelo clique numa célula da `Tabela`):
+   - Ignora se a categoria já tem valor (não deixa sobrescrever categoria preenchida).
+   - Se o jogador já havia marcado outra célula **nesta mesma rodada** (`marcouPonto`),
+     desfaz a marcação anterior antes de aplicar a nova — permitindo **trocar de escolha**
+     antes de confirmar.
+   - Grava o valor, soma no `total` e guarda em `voltarJogada`.
+2. **`proximoJogador()`** (botão **Confirmar**):
+   - Só age se `marcouPonto` for `true`.
+   - Empurra a jogada para `historicoJogadas`.
+   - Reseta `marcouPonto`, avança `jogadorAtual` de forma circular (`% jogadores.length`)
+     e chama `fimDoJogo()`.
+3. **`voltarJogadaHandler()`** (botão **voltar**):
+   - Desempilha a última jogada confirmada de `historicoJogadas`, zera aquela categoria,
+     subtrai do `total` e devolve a vez ao jogador que a fez.
+4. **`fimDoJogo()`**:
+   - Verifica se **todas** as categorias de **todos** os jogadores estão preenchidas.
+   - Se sim, ordena por `total` desc, marca `vencedor` para quem tem a maior pontuação
+     (permite múltiplos vencedores em empate) e liga `gameOver`.
+
+> ⚠️ **Nota de implementação:** `marcouPonto` distingue a jogada **em andamento** (ainda
+> trocável antes de confirmar) da jogada **confirmada** (que vai para o `historicoJogadas`).
+> São dois mecanismos de "desfazer" diferentes: trocar a célula antes de confirmar vs.
+> voltar uma jogada já confirmada.
+
+### `Tabela.jsx`
+
+- Renderiza `arrayPontos`, a definição estática das categorias e suas pontuações possíveis.
+- Cada célula chama `setPonto(jogadorAtual, valor, nomePropriedade)` no clique.
+- Classes CSS: `marcado` (célula escolhida na rodada), `preenchido` (categoria já fechada
+  com outro valor). As linhas especiais usam `colSpan={2}`.
+
+### `FimDeJogo.jsx`
+
+- Recebe o ranking já ordenado e decide o emoji de cada colocado (`getEmoji`):
+  troféu (vencedor), aperto de mão (empate), olhos arregalados (diferença ≤ 10 pts) e
+  pato (demais).
+- Botões: `Recomeçar partida` (`onRecomecarPartida` → mantém jogadores, zera placar) e
+  `Nova partida` (`onGameReset` → volta ao cadastro).
+
+## Roadmap / implementações futuras
+
+_(itens migrados dos antigos TODOs do README + decisões recentes)_
+
+- [ ] **Tela de abertura / splash** (loading ao abrir o app).
+- [ ] **Modo de jogo selecionável no início da partida:**
+      - _Clássico_ (comportamento atual: total é a soma direta das categorias).
+      - _Com bônus de seção superior_: se a soma das categorias numéricas (1 a 6) atingir
+        **63 ou mais**, o jogador ganha **+35 pontos** de bônus (regra do Yahtzee clássico).
+      A escolha do modo deve ser feita na tela de cadastro, antes de iniciar.
+- [ ] **Testes unitários para validar as pontuações** — cobrir o cálculo de pontos das
+      categorias numéricas e especiais, a soma do `total`, o "de mão" (valores extras) e a
+      lógica de fim de jogo/ranking (incluindo empates). Não há suíte de testes hoje;
+      será preciso escolher e configurar um runner (ex.: Jest + React Testing Library).
+- [ ] **Corrigir imports repetidos de CSS** — ver
+      [issue #2](https://github.com/gabrielkgg/marcador-general/issues/2).
+- [ ] **Publicar nas lojas** (App Store e Play Store) via Capacitor.
+- [ ] **README bonito** 🥰 (em andamento com esta reorganização de docs).
+
+## Bugs conhecidos / limitações
+
+- **Sem bônus de seção superior** — o total é sempre a soma direta (ver roadmap para o
+  modo selecionável).
+- **Cadastro permite 1 jogador** — o mínimo do seletor é 1, mas o jogo pressupõe 2+.
+- **Validação de nomes frágil** — `handleSalvar` só checa `nomes.length`, não campos vazios
+  entre jogadores; é possível iniciar com nomes em branco em certas situações.
+- **Estado apenas em memória** — recarregar a página perde a partida em andamento (sem
+  persistência).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,69 @@
 # marcador-general
 
-Aplicação para marcar pontos de general (jogo de dados)
+Aplicação para marcar pontos de **General** (também conhecido como _Yahtzee_), um jogo de dados.
+
+O app é um **placar**: ele não rola dados nem controla as jogadas físicas. Os jogadores jogam com os dados de verdade e usam o app para registrar a pontuação de cada rodada e apontar o vencedor no fim.
 
 Link do protótipo: https://www.figma.com/design/w2wDnNJYO2hEUXcqDhLEAc/General-%5B2024%5D
 
-TODO:
+> Procurando detalhes de arquitetura, como rodar o projeto ou o que planejamos implementar? Veja [DOCUMENTATION.md](./DOCUMENTATION.md).
 
--   Fazer tela de abertura (loading quando abre o app)
--   Corrigir imports repetidos de CSS https://github.com/gabrielkgg/marcador-general/issues/2
--   Investigar como colocar esta aplicação na App Store e Play Store
--   Fazer um Readme bonitinho 🥰
+## Objetivo
+
+O jogo é jogado com **5 dados** entre **2 ou mais jogadores**. Cada jogador preenche todas as categorias da tabela ao longo da partida; ao final, **quem tiver a maior pontuação total vence**. Em caso de empate, todos com a maior pontuação são considerados vencedores.
+
+## Como jogar
+
+1. **Cadastre os jogadores** na tela inicial (nome de cada um).
+2. A partida acontece em **turnos alternados**. Na sua vez, você rola os dados de verdade e escolhe **uma** categoria para registrar.
+3. Toque na célula da tabela correspondente à pontuação que você fez e confirme a jogada com o botão **Confirmar**.
+4. A vez passa para o próximo jogador. Isso se repete até **todos preencherem todas as categorias**.
+5. Quando a tabela de todos estiver completa, o app mostra a tela de **Fim de jogo** com o ranking e o vencedor.
+
+Cada categoria só pode ser preenchida **uma vez por jogador**. Depois de confirmada, ela não pode mais ser alterada.
+
+### Riscar / anular uma categoria
+
+Se você não conseguiu (ou não quis) fazer uma combinação, pode **anular** aquela categoria marcando o valor **0**. Isso "queima" o espaço com zero pontos — útil quando não há mais como pontuar nela.
+
+## Categorias e pontuação
+
+A tabela tem duas partes: as **categorias numéricas** (1 a 6) e as **combinações especiais**.
+
+### Categorias numéricas (1 a 6)
+
+Você soma apenas os dados de um mesmo número. A pontuação é `quantidade de dados × valor do número` (de 0 a 5 dados):
+
+| Categoria | Pontuações possíveis |
+| --------- | -------------------- |
+| 1         | 0, 1, 2, 3, 4, 5     |
+| 2         | 0, 2, 4, 6, 8, 10    |
+| 3         | 0, 3, 6, 9, 12, 15   |
+| 4         | 0, 4, 8, 12, 16, 20  |
+| 5         | 0, 5, 10, 15, 20, 25 |
+| 6         | 0, 6, 12, 18, 24, 30 |
+
+### Combinações especiais
+
+| Categoria           | Combinação                                | Pontos | "De mão" |
+| ------------------- | ----------------------------------------- | ------ | -------- |
+| **Fula** (Full)     | Uma trinca + um par                       | 20     | 25       |
+| **Seq.** (Sequência)| Cinco dados em sequência                  | 30     | 35       |
+| **Quad.** (Quadra)  | Quatro dados iguais                       | 40     | 45       |
+| **Gen.** (General)  | Cinco dados iguais                        | 50     | —        |
+| **De Mão**          | General feito "de mão" (cinco iguais direto) | —   | 100      |
+
+### O que significa "de mão"
+
+Uma combinação é **"de mão"** quando os cinco dados saem prontos **já na primeira jogada, sem congelar (freeze) nem re-rolar nenhum dado**. Nesse caso ela vale o valor extra (a coluna "De mão" da tabela acima). O General "de mão" é tão valioso que tem sua própria linha, valendo **100 pontos**.
+
+## Fim de jogo
+
+Quando todos completam a tabela, o app exibe o ranking ordenado por pontuação, sinalizado com emojis:
+
+- 🏆 vencedor(es)
+- 🤝 empate na pontuação
+- 😳 disputa apertada (diferença de até 10 pontos para o vizinho no ranking)
+- 🦆 demais colocados
+
+Na tela de fim de jogo é possível **Recomeçar partida** (mesmos jogadores, placar zerado) ou iniciar uma **Nova partida** (volta ao cadastro de jogadores).

--- a/src/components/Marcador.jsx
+++ b/src/components/Marcador.jsx
@@ -127,7 +127,10 @@ export function Marcador({ nomes, onGameReset }) {
         );
 
         if (todosPontosMarcados) {
-            const jogadoresOrdenados = jogadores.sort(
+            // Ordena sobre uma cópia para não mutar o array de estado `jogadores`.
+            // Mutar aqui reordenava os jogadores por pontuação, e ao "Recomeçar
+            // partida" eles reiniciavam fora da ordem de cadastro.
+            const jogadoresOrdenados = [...jogadores].sort(
                 (a, b) => b.pontos.total - a.pontos.total
             );
 


### PR DESCRIPTION
O `fimDoJogo()` ordenava o array de estado `jogadores` in place com `.sort()`, reordenando-o por pontuação. Ao "Recomeçar partida", os jogadores reiniciavam na ordem de pontos (vencedor primeiro) em vez da ordem de cadastro, bagunçando a mesa. Agora a ordenação é feita sobre uma cópia (`[...jogadores].sort()`), preservando a ordem original.

Também adiciona documentação: README com as regras do jogo e DOCUMENTATION.md com visão técnica, arquitetura e roadmap.