### PR TITLE
fix: elimina CSS duplicado em varias tags <style> (#2)

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -38,7 +38,8 @@ src/
     Marcador.jsx           # coração do jogo: estado da partida, turnos, histórico
     Tabela.jsx             # grade de categorias × pontuações clicáveis
     FimDeJogo.jsx          # ranking final, emojis, recomeçar/nova partida
-  styles/                # SCSS por componente + parciais (_variaveis, _botoes, _flex...)
+  styles/                # global.scss (base/utilitárias, importado 1x em App.jsx) +
+                         # SCSS por componente + parciais (_variaveis, _fontes, _botoes...)
   assets/                # logo, ícones (svg), favicon
 ```
 
@@ -147,10 +148,7 @@ _(itens migrados dos antigos TODOs do README + decisões recentes)_
       categorias numéricas e especiais, a soma do `total`, o "de mão" (valores extras) e a
       lógica de fim de jogo/ranking (incluindo empates). Não há suíte de testes hoje;
       será preciso escolher e configurar um runner (ex.: Jest + React Testing Library).
-- [ ] **Corrigir imports repetidos de CSS** — ver
-      [issue #2](https://github.com/gabrielkgg/marcador-general/issues/2).
 - [ ] **Publicar nas lojas** (App Store e Play Store) via Capacitor.
-- [ ] **README bonito** 🥰 (em andamento com esta reorganização de docs).
 
 ## Bugs conhecidos / limitações
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { CadastroJogadores } from './components/CadastroJogadores';
 import { Marcador } from './components/Marcador';
-import './styles/App.scss';
+import './styles/global.scss';
 import logo from './assets/logo.png';
 import reset from './assets/arrow-rotate-left-solid-full.svg';
 

--- a/src/styles/CadastroJogadores.scss
+++ b/src/styles/CadastroJogadores.scss
@@ -1,4 +1,4 @@
-@import '_all';
+@use 'variaveis' as *;
 
 .quantidade-jogadores {
     font-size: $font-size;

--- a/src/styles/FimDeJogo.scss
+++ b/src/styles/FimDeJogo.scss
@@ -1,4 +1,4 @@
-@import '_all';
+@use 'variaveis' as *;
 
 .fim-de-jogo {
     &-holder {

--- a/src/styles/Tabela.scss
+++ b/src/styles/Tabela.scss
@@ -1,4 +1,4 @@
-@import '_variaveis';
+@use 'variaveis' as *;
 
 table {
     color: $font-white;

--- a/src/styles/_all.scss
+++ b/src/styles/_all.scss
@@ -1,3 +1,0 @@
-@import '_flex';
-@import '_variaveis';
-@import '_botoes';

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -1,4 +1,5 @@
-@import '_all';
+// Reset e estilos globais de elementos. Emitidos uma única vez via global.scss.
+@use 'variaveis' as *;
 
 * {
     margin: 0;

--- a/src/styles/_botoes.scss
+++ b/src/styles/_botoes.scss
@@ -1,4 +1,4 @@
-@import '_variaveis';
+@use 'variaveis' as *;
 
 .botao-padrao {
     background: linear-gradient(90deg, #2413a1 0%, #0092e6 100%);

--- a/src/styles/_fontes.scss
+++ b/src/styles/_fontes.scss
@@ -1,0 +1,27 @@
+// Classes utilitárias de fonte (globais). Emitidas uma única vez via global.scss.
+
+.font {
+    &-regular {
+        font-family: 'Roboto Slab', sans-serif;
+        font-weight: 400;
+        font-style: normal;
+    }
+
+    &-medium {
+        font-family: 'Roboto Slab', sans-serif;
+        font-weight: 500;
+        font-style: normal;
+    }
+
+    &-bold {
+        font-family: 'Roboto Slab', sans-serif;
+        font-weight: 700;
+        font-style: normal;
+    }
+
+    &-regular-italic {
+        font-family: 'Roboto Slab', sans-serif;
+        font-weight: 400;
+        font-style: italic;
+    }
+}

--- a/src/styles/_variaveis.scss
+++ b/src/styles/_variaveis.scss
@@ -1,4 +1,5 @@
-@import '_flex.scss';
+// Apenas variáveis de tema — este arquivo NÃO emite CSS.
+// Use com `@use 'variaveis' as *;` nos arquivos que precisarem das variáveis.
 
 $padding: 0.3em 1em;
 $font-white: #ececec;
@@ -9,29 +10,3 @@ $background-holder: #191440;
 $padding-holder: 15px;
 $background-gradient: linear-gradient(180deg, #13082f 0%, #2413a1 100%);
 $border-color: #b9b5c1;
-
-.font {
-    &-regular {
-        font-family: 'Roboto Slab', sans-serif;
-        font-weight: 400;
-        font-style: normal;
-    }
-
-    &-medium {
-        font-family: 'Roboto Slab', sans-serif;
-        font-weight: 500;
-        font-style: normal;
-    }
-
-    &-bold {
-        font-family: 'Roboto Slab', sans-serif;
-        font-weight: 700;
-        font-style: normal;
-    }
-
-    &-regular-italic {
-        font-family: 'Roboto Slab', sans-serif;
-        font-weight: 400;
-        font-style: italic;
-    }
-}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,0 +1,7 @@
+// Folha de estilo global. Importada UMA única vez em App.jsx.
+// Cada parcial é carregado via @use, que garante emissão única do CSS
+// (sem as tags <style> repetidas que motivaram a issue #2).
+@use 'base';
+@use 'flex';
+@use 'fontes';
+@use 'botoes';


### PR DESCRIPTION
Os arquivos SCSS usavam @import com um grafo em diamante (_variaveis e _botoes reimportavam _flex, e App/Cadastro/FimDeJogo importavam _all cada um). Como @import inlina o CSS sem deduplicar e cada componente injeta sua propria <style> via style-loader, as regras base (.font-*, .flex, .botao-*) apareciam repetidas em varias tags.

Reorganiza os estilos:
- _variaveis.scss passa a conter apenas variaveis (nao emite CSS)
- classes .font-* movidas para _fontes.scss
- regras globais/reset movidas de App.scss para _base.scss
- global.scss reune base/flex/fontes/botoes via @use e e importado 1x em App.jsx
- componentes usam @use 'variaveis' as * e contem so suas regras
- remove _all.scss e App.scss

Migra @import -> @use, que deduplica por compilacao e encerra os warnings de depreciacao do Sass. Build validado; regras globais agora saem 1x.

Fecha #2.