### PR TITLE
feat: adiciona splash screen de abertura

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -34,6 +34,7 @@ src/
   index.html             # template do HtmlWebpackPlugin
   App.jsx                # raiz: alterna entre cadastro e partida; header + reset
   components/
+    Splash.jsx             # tela de abertura (logo + spinner) exibida 1x ao abrir
     CadastroJogadores.jsx  # tela inicial: nº de jogadores + nomes
     Marcador.jsx           # coração do jogo: estado da partida, turnos, histórico
     Tabela.jsx             # grade de categorias × pontuações clicáveis
@@ -53,6 +54,10 @@ O app tem essencialmente **dois modos**, controlados por `App.jsx` via `partidaI
 ### `App.jsx`
 
 - `partidaIniciada` (bool) e `nomes` (array de jogadores).
+- **Splash de abertura**: `mostrarSplash`/`fechandoSplash` controlam a `<Splash />`,
+  exibida como overlay uma única vez ao montar o app. Um `useEffect` com dois `setTimeout`
+  dispara o fade-out após `SPLASH_DURACAO_MS` (3s) e desmonta a splash após o fade
+  (`SPLASH_FADE_MS`, 300ms). Os timers são limpos no cleanup.
 - `handleGameStart(jogadores)`: recebe a lista pronta do cadastro e entra na partida.
 - `handleGameReset()`: confirma via `confirm()` e volta ao cadastro (**nova partida**).
 
@@ -138,7 +143,6 @@ Fluxo de uma jogada:
 
 _(itens migrados dos antigos TODOs do README + decisões recentes)_
 
-- [ ] **Tela de abertura / splash** (loading ao abrir o app).
 - [ ] **Modo de jogo selecionável no início da partida:**
       - _Clássico_ (comportamento atual: total é a soma direta das categorias).
       - _Com bônus de seção superior_: se a soma das categorias numéricas (1 a 6) atingir

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,36 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CadastroJogadores } from './components/CadastroJogadores';
 import { Marcador } from './components/Marcador';
+import { Splash } from './components/Splash';
 import './styles/global.scss';
 import logo from './assets/logo.png';
 import reset from './assets/arrow-rotate-left-solid-full.svg';
 
+const SPLASH_DURACAO_MS = 3000;
+const SPLASH_FADE_MS = 300;
+
 function App() {
     const [partidaIniciada, setPartidaIniciada] = useState(false);
     const [nomes, setNomes] = useState([]);
+    const [mostrarSplash, setMostrarSplash] = useState(true);
+    const [fechandoSplash, setFechandoSplash] = useState(false);
+
+    // Splash de abertura: exibida uma única vez ao montar o app.
+    // Após SPLASH_DURACAO_MS inicia o fade-out e, ao fim dele, é desmontada.
+    useEffect(() => {
+        const timerFade = setTimeout(() => {
+            setFechandoSplash(true);
+        }, SPLASH_DURACAO_MS);
+
+        const timerRemover = setTimeout(() => {
+            setMostrarSplash(false);
+        }, SPLASH_DURACAO_MS + SPLASH_FADE_MS);
+
+        return () => {
+            clearTimeout(timerFade);
+            clearTimeout(timerRemover);
+        };
+    }, []);
 
     const handleGameStart = (nomes) => {
         setPartidaIniciada(true);
@@ -23,6 +46,7 @@ function App() {
 
     return (
         <>
+            {mostrarSplash && <Splash fechando={fechandoSplash} />}
             <header>
                 <div className="header-holder">
                     {partidaIniciada ? (

--- a/src/components/Splash.jsx
+++ b/src/components/Splash.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './../styles/Splash.scss';
+import logo from './../assets/logo.png';
+
+export function Splash({ fechando }) {
+    return (
+        <div className={`splash ${fechando ? 'splash-fechando' : ''}`}>
+            <img src={logo} alt="Logo Marcador General" className="splash-logo" />
+            <div className="splash-spinner" aria-label="Carregando" />
+        </div>
+    );
+}

--- a/src/styles/Splash.scss
+++ b/src/styles/Splash.scss
@@ -1,0 +1,43 @@
+@use 'variaveis' as *;
+
+.splash {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2em;
+
+    background: $background-gradient;
+
+    // Estado inicial visível; o fade-out é controlado por .splash-fechando
+    opacity: 1;
+    transition: opacity 300ms ease;
+
+    &-fechando {
+        opacity: 0;
+    }
+
+    &-logo {
+        width: 120px;
+        height: auto;
+    }
+
+    &-spinner {
+        width: 44px;
+        height: 44px;
+        border-radius: 50%;
+        border: 4px solid rgba(236, 236, 236, 0.25);
+        border-top-color: $font-white;
+        animation: splash-spin 0.8s linear infinite;
+    }
+}
+
+@keyframes splash-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}


### PR DESCRIPTION
Exibe uma tela de abertura (logo + spinner circular) uma unica vez ao abrir o app. Apos 3s inicia um fade-out de 300ms que revela a tela de cadastro por baixo. Timers sao limpos no cleanup do efeito.

Novo componente Splash + estilos (overlay tela cheia, spinner via @keyframes) e controle de exibicao em App.jsx.