### PR TITLE
fix: corrige warnings de DOM na Tabela e separacao de secoes

### DIFF
--- a/src/components/Tabela.jsx
+++ b/src/components/Tabela.jsx
@@ -55,8 +55,8 @@ export function Tabela({ jogadorAtual, jogadores, setPonto }) {
                         ].includes(nomePropriedade);
 
                         return (
-                            <>
-                                <tr key={indexPontos}>
+                            <React.Fragment key={indexPontos}>
+                                <tr>
                                     <th>{legenda}</th>
                                     {valores.map((valor, indexValor) => (
                                         <td
@@ -86,8 +86,24 @@ export function Tabela({ jogadorAtual, jogadores, setPonto }) {
                                         </td>
                                     ))}
                                 </tr>
-                                {indexPontos === 5 && <br />}{' '}
-                            </>
+                                {/* Linhas espaçadoras entre os números (1–6) e as especiais */}
+                                {indexPontos === 5 && (
+                                    <>
+                                        <tr
+                                            className="linha-separadora"
+                                            aria-hidden="true"
+                                        >
+                                            <td colSpan={7} />
+                                        </tr>
+                                        <tr
+                                            className="linha-separadora"
+                                            aria-hidden="true"
+                                        >
+                                            <td colSpan={7} />
+                                        </tr>
+                                    </>
+                                )}
+                            </React.Fragment>
                         );
                     })}
                 </tbody>

--- a/src/styles/Tabela.scss
+++ b/src/styles/Tabela.scss
@@ -30,3 +30,16 @@ td {
         opacity: 0.4;
     }
 }
+
+// Linha espaçadora entre as categorias numéricas (1–6) e as especiais.
+// Substitui o antigo <br> dentro do <tbody> (HTML inválido) sem interferir
+// no arredondamento das células.
+// Duas linhas espaçadoras entre as categorias numéricas (1–6) e as especiais.
+// Substituem o antigo <br> dentro do <tbody> (HTML inválido); o espaço vem da
+// própria existência das linhas (border-spacing da tabela), já que ajustar
+// height/padding em <td> vazio não surte efeito confiável.
+.linha-separadora td {
+    font-size: 0;
+    background: transparent;
+    border-radius: 0;
+}


### PR DESCRIPTION
A Tabela emitia tres warnings do React ao renderizar: key ausente no elemento raiz do map, e um <br> + whitespace invalidos como filhos diretos de <tbody> (usados para separar as categorias numericas das especiais).

- move a key para um React.Fragment que envolve cada linha
- remove o <br> e o whitespace do <tbody>
- separa as secoes com linhas <tr> espacadoras (DOM valido)