### PR TITLE
feat: adiciona modo de jogo com bonus de secao superior e exige 2+ jogadores

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -66,7 +66,11 @@ O app tem essencialmente **dois modos**, controlados por `App.jsx` via `partidaI
 - Controla `numJogadores` (1–20, default 2) e `nomes[]`.
 - Botões `+`/`-` e input numérico ajustam a quantidade; `useEffect` liga/desliga os
   botões nos limites (1 e 20).
-- `handleSalvar()` monta o array de jogadores no formato canônico e chama `onGameStart`.
+- `handleSalvar()` monta o array de jogadores no formato canônico e chama
+  `onGameStart(jogadores, modo)`.
+- **Modo de jogo**: estado `modo` (`'classico'` default | `'bonus'`), escolhido num toggle
+  de dois botões acima de "Iniciar partida". No modo `'bonus'`, atingir 63+ nas categorias
+  numéricas (1 a 6) rende +35 pontos.
 
 **Formato do jogador** (a "fonte da verdade" do placar):
 
@@ -82,7 +86,12 @@ O app tem essencialmente **dois modos**, controlados por `App.jsx` via `partidaI
 ```
 
 Cada categoria começa `undefined` (= ainda não preenchida) e recebe um número ao ser
-marcada. `total` acumula a soma.
+marcada. `total` acumula a soma **das categorias** (sem o bônus).
+
+> **Bônus de seção superior:** no modo `'bonus'`, o `Marcador` **deriva** o bônus a partir
+> das categorias 1–6 (`calcularBonus`/`totalComBonus`) em vez de guardá-lo em `pontos`.
+> Assim ele acompanha automaticamente as jogadas e o "voltar jogada", e o total exibido/
+> ranqueado é `total + bônus`. Constantes: `BONUS_LIMIAR = 63`, `BONUS_VALOR = 35`.
 
 ### `Marcador.jsx` (núcleo)
 
@@ -143,11 +152,6 @@ Fluxo de uma jogada:
 
 _(itens migrados dos antigos TODOs do README + decisões recentes)_
 
-- [ ] **Modo de jogo selecionável no início da partida:**
-      - _Clássico_ (comportamento atual: total é a soma direta das categorias).
-      - _Com bônus de seção superior_: se a soma das categorias numéricas (1 a 6) atingir
-        **63 ou mais**, o jogador ganha **+35 pontos** de bônus (regra do Yahtzee clássico).
-      A escolha do modo deve ser feita na tela de cadastro, antes de iniciar.
 - [ ] **Testes unitários para validar as pontuações** — cobrir o cálculo de pontos das
       categorias numéricas e especiais, a soma do `total`, o "de mão" (valores extras) e a
       lógica de fim de jogo/ranking (incluindo empates). Não há suíte de testes hoje;
@@ -156,9 +160,6 @@ _(itens migrados dos antigos TODOs do README + decisões recentes)_
 
 ## Bugs conhecidos / limitações
 
-- **Sem bônus de seção superior** — o total é sempre a soma direta (ver roadmap para o
-  modo selecionável).
-- **Cadastro permite 1 jogador** — o mínimo do seletor é 1, mas o jogo pressupõe 2+.
 - **Validação de nomes frágil** — `handleSalvar` só checa `nomes.length`, não campos vazios
   entre jogadores; é possível iniciar com nomes em branco em certas situações.
 - **Estado apenas em memória** — recarregar a página perde a partida em andamento (sem

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ Você soma apenas os dados de um mesmo número. A pontuação é `quantidade de 
 
 Uma combinação é **"de mão"** quando os cinco dados saem prontos **já na primeira jogada, sem congelar (freeze) nem re-rolar nenhum dado**. Nesse caso ela vale o valor extra (a coluna "De mão" da tabela acima). O General "de mão" é tão valioso que tem sua própria linha, valendo **100 pontos**.
 
+## Modos de jogo
+
+Ao cadastrar os jogadores, você escolhe o modo da partida:
+
+- **Clássico** — a pontuação total é a soma direta de todas as categorias.
+- **Com bônus** — adiciona o **bônus de seção superior**: se a soma das suas **categorias numéricas (1 a 6)** atingir **63 pontos ou mais**, você ganha **+35 pontos** de bônus.
+
+No modo com bônus, o placar mostra um indicador de quanto ainda **falta para o bônus** enquanto você não atinge os 63; ao alcançar, o bônus é somado ao total e sinalizado. Como o bônus depende só das categorias numéricas, uma vez atingido ele não é perdido (a não ser que você desfaça uma jogada que o tenha garantido).
+
+> 💡 Precisa de **pelo menos 2 jogadores** para iniciar uma partida — não dá para jogar sozinho.
+
 ## Fim de jogo
 
 Quando todos completam a tabela, o app exibe o ranking ordenado por pontuação, sinalizado com emojis:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ const SPLASH_FADE_MS = 300;
 function App() {
     const [partidaIniciada, setPartidaIniciada] = useState(false);
     const [nomes, setNomes] = useState([]);
+    const [modo, setModo] = useState('classico');
     const [mostrarSplash, setMostrarSplash] = useState(true);
     const [fechandoSplash, setFechandoSplash] = useState(false);
 
@@ -32,9 +33,10 @@ function App() {
         };
     }, []);
 
-    const handleGameStart = (nomes) => {
+    const handleGameStart = (nomes, modo) => {
         setPartidaIniciada(true);
         setNomes(nomes);
+        setModo(modo);
     };
 
     const handleGameReset = () => {
@@ -74,7 +76,11 @@ function App() {
             {!partidaIniciada ? (
                 <CadastroJogadores onGameStart={handleGameStart} />
             ) : (
-                <Marcador nomes={nomes} onGameReset={handleGameReset} />
+                <Marcador
+                    nomes={nomes}
+                    modo={modo}
+                    onGameReset={handleGameReset}
+                />
             )}
         </>
     );

--- a/src/components/CadastroJogadores.jsx
+++ b/src/components/CadastroJogadores.jsx
@@ -1,36 +1,43 @@
 import React, { useEffect, useState } from 'react';
 import './../styles/CadastroJogadores.scss';
 
+// O jogo exige no mínimo 2 jogadores (não se joga sozinho).
+const MIN_JOGADORES = 2;
+const MAX_JOGADORES = 20;
+
 export function CadastroJogadores({ onGameStart }) {
     const [numJogadores, setNumJogadores] = useState(2);
     const [nomes, setNomes] = useState([]);
     const [podeDiminuirJogador, setPodeDiminuirJogador] = useState(true);
     const [podeAumentarJogador, setPodeAumentarJogador] = useState(true);
+    // Modo de jogo: 'classico' (soma direta) ou 'bonus' (63+ nos números rende +35)
+    const [modo, setModo] = useState('classico');
 
     const handleNumJogadoresChange = (e) => {
         let valor = parseInt(e.target.value, 10);
 
-        // Permite valor vazio temporariamente, mas impede que seja menor que 1
+        // Permite valor vazio temporariamente; o clamp final ocorre no blur.
         if (
             valor === '' ||
-            (parseInt(valor, 10) >= 1 && parseInt(valor, 10) <= 20)
+            (parseInt(valor, 10) >= MIN_JOGADORES &&
+                parseInt(valor, 10) <= MAX_JOGADORES)
         ) {
             setNumJogadores(valor);
         }
     };
 
     const handleBlur = () => {
-        // Se o valor for vazio ao sair do campo, redefine para 1
-        if (numJogadores === '' || numJogadores < 1) {
-            setNumJogadores(1);
-        } else if (numJogadores > 20) {
-            setNumJogadores(20);
+        // Ao sair do campo, garante que fique dentro dos limites válidos.
+        if (numJogadores === '' || numJogadores < MIN_JOGADORES) {
+            setNumJogadores(MIN_JOGADORES);
+        } else if (numJogadores > MAX_JOGADORES) {
+            setNumJogadores(MAX_JOGADORES);
         }
     };
 
     const handleMenosJogador = () => {
-        // Não diminuir jogador se só tiver um
-        if (numJogadores === 1) {
+        // Não diminuir abaixo do mínimo de jogadores
+        if (numJogadores <= MIN_JOGADORES) {
             return;
         }
         setNumJogadores(numJogadores - 1);
@@ -39,17 +46,17 @@ export function CadastroJogadores({ onGameStart }) {
     useEffect(() => {
         setPodeDiminuirJogador(true);
         setPodeAumentarJogador(true);
-        if (numJogadores === 20) {
+        if (numJogadores === MAX_JOGADORES) {
             setPodeAumentarJogador(false);
         }
-        if (numJogadores === 1) {
+        if (numJogadores === MIN_JOGADORES) {
             setPodeDiminuirJogador(false);
         }
     }, [numJogadores]);
 
     const handleMaisJogador = () => {
-        // Não deixa passar de 20 jogadores
-        if (numJogadores === 20) {
+        // Não deixa passar do máximo de jogadores
+        if (numJogadores === MAX_JOGADORES) {
             return;
         }
         setNumJogadores(numJogadores + 1);
@@ -62,6 +69,12 @@ export function CadastroJogadores({ onGameStart }) {
     };
 
     const handleSalvar = () => {
+        // Não é possível jogar sozinho.
+        if (numJogadores < MIN_JOGADORES) {
+            alert('São necessários pelo menos 2 jogadores para iniciar');
+            return;
+        }
+
         if (nomes.length < numJogadores) {
             alert('Preencha corretamente o nome de todos os jogadores');
             return;
@@ -84,7 +97,7 @@ export function CadastroJogadores({ onGameStart }) {
                 total: 0,
             },
         }));
-        onGameStart(jogadores);
+        onGameStart(jogadores, modo);
     };
 
     return (
@@ -99,13 +112,17 @@ export function CadastroJogadores({ onGameStart }) {
                     </button>
                     <input
                         type="number"
-                        value={numJogadores >= 1 ? numJogadores : 1}
+                        value={
+                            numJogadores >= MIN_JOGADORES
+                                ? numJogadores
+                                : MIN_JOGADORES
+                        }
                         onChange={handleNumJogadoresChange}
                         onBlur={handleBlur}
                         inputMode="numeric"
                         className="font-bold"
-                        min="1"
-                        max="20"
+                        min={MIN_JOGADORES}
+                        max={MAX_JOGADORES}
                     />
                     <button
                         className={`plus font-bold ${podeAumentarJogador ? '' : 'desativado'}`}
@@ -132,6 +149,34 @@ export function CadastroJogadores({ onGameStart }) {
                         />
                     </div>
                 ))}
+            </div>
+            <div className="modo-jogo">
+                <span className="modo-jogo-titulo font-medium">
+                    Modo de jogo
+                </span>
+                <div className="flex modo-jogo-opcoes">
+                    <button
+                        className={`modo-jogo-botao font-regular ${
+                            modo === 'classico' ? 'ativo' : ''
+                        }`}
+                        onClick={() => setModo('classico')}
+                    >
+                        Clássico
+                    </button>
+                    <button
+                        className={`modo-jogo-botao font-regular ${
+                            modo === 'bonus' ? 'ativo' : ''
+                        }`}
+                        onClick={() => setModo('bonus')}
+                    >
+                        Com bônus
+                    </button>
+                </div>
+                {modo === 'bonus' && (
+                    <span className="modo-jogo-dica font-regular">
+                        63+ nos números (1–6) rende +35 pontos
+                    </span>
+                )}
             </div>
             <div>
                 <button

--- a/src/components/FimDeJogo.jsx
+++ b/src/components/FimDeJogo.jsx
@@ -54,6 +54,12 @@ export function FimDeJogo({ listaJogadores, onGameReset, onRecomecarPartida }) {
                                 </div>
                                 <div className="fim-de-jogo-pontos font-regular">
                                     {jogador.pontos} pontos
+                                    {jogador.bonus && (
+                                        <span className="fim-de-jogo-bonus">
+                                            {' '}
+                                            (inclui bônus +35)
+                                        </span>
+                                    )}
                                 </div>
                             </div>
                             <div className="fim-de-jogo-icone">

--- a/src/components/Marcador.jsx
+++ b/src/components/Marcador.jsx
@@ -5,7 +5,20 @@ import './../styles/Marcador.scss';
 import check from './../assets/check-solid.svg';
 import voltar from './../assets/arrow-left-solid-full.svg';
 
-export function Marcador({ nomes, onGameReset }) {
+// Bônus de seção superior (modo 'bonus'): se a soma das categorias numéricas
+// (1 a 6) atingir BONUS_LIMIAR, o jogador ganha BONUS_VALOR pontos.
+const CATEGORIAS_SUPERIORES = [
+    'ones',
+    'twos',
+    'threes',
+    'fours',
+    'fives',
+    'sixes',
+];
+const BONUS_LIMIAR = 63;
+const BONUS_VALOR = 35;
+
+export function Marcador({ nomes, modo, onGameReset }) {
     const [jogadores, setJogadores] = useState(nomes);
     const [jogadorAtual, setJogadorAtual] = useState(0);
     const [marcouPonto, setMarcouPonto] = useState(false);
@@ -14,6 +27,44 @@ export function Marcador({ nomes, onGameReset }) {
     const [voltarJogada, setVoltarJogada] = useState({});
     // Histórico de jogadas confirmadas: array de objetos { jogadorIndex, categoria, pontos }
     const [historicoJogadas, setHistoricoJogadas] = useState([]);
+
+    // Soma das categorias numéricas (1–6) já marcadas.
+    const somaSecaoSuperior = (pontos) =>
+        CATEGORIAS_SUPERIORES.reduce(
+            (soma, categoria) => soma + (pontos[categoria] || 0),
+            0
+        );
+
+    const secaoSuperiorCompleta = (pontos) =>
+        CATEGORIAS_SUPERIORES.every(
+            (categoria) => pontos[categoria] !== undefined
+        );
+
+    // Bônus derivado das categorias 1–6 (não é armazenado): recalculado a cada
+    // render, então acompanha automaticamente as jogadas e o "voltar jogada".
+    const calcularBonus = (pontos) => {
+        if (modo !== 'bonus') {
+            return 0;
+        }
+        return somaSecaoSuperior(pontos) >= BONUS_LIMIAR ? BONUS_VALOR : 0;
+    };
+
+    // Quantos pontos ainda faltam para o bônus. Retorna null quando não se
+    // aplica: fora do modo bônus, já alcançado, ou a seção superior já fechou
+    // (não há mais como atingir o limiar).
+    const faltaParaBonus = (pontos) => {
+        if (modo !== 'bonus') {
+            return null;
+        }
+        const restante = BONUS_LIMIAR - somaSecaoSuperior(pontos);
+        if (restante <= 0 || secaoSuperiorCompleta(pontos)) {
+            return null;
+        }
+        return restante;
+    };
+
+    // Total exibido/ranqueado = soma das categorias + eventual bônus de seção.
+    const totalComBonus = (pontos) => pontos.total + calcularBonus(pontos);
 
     const recomecarPartida = () => {
         // Reseta o jogo mantendo os mesmos jogadores e ordem
@@ -131,17 +182,18 @@ export function Marcador({ nomes, onGameReset }) {
             // Mutar aqui reordenava os jogadores por pontuação, e ao "Recomeçar
             // partida" eles reiniciavam fora da ordem de cadastro.
             const jogadoresOrdenados = [...jogadores].sort(
-                (a, b) => b.pontos.total - a.pontos.total
+                (a, b) => totalComBonus(b.pontos) - totalComBonus(a.pontos)
             );
 
             // Encontra a maior pontuação (primeiro jogador na lista ordenada)
-            const maiorPontuacao = jogadoresOrdenados[0].pontos.total;
+            const maiorPontuacao = totalComBonus(jogadoresOrdenados[0].pontos);
 
             const listaNomes = jogadoresOrdenados.map((jogador) => {
                 return {
                     nome: jogador.nome,
-                    pontos: jogador.pontos.total,
-                    vencedor: maiorPontuacao === jogador.pontos.total,
+                    pontos: totalComBonus(jogador.pontos),
+                    bonus: calcularBonus(jogador.pontos) > 0,
+                    vencedor: maiorPontuacao === totalComBonus(jogador.pontos),
                 };
             });
             setListaNomes(listaNomes);
@@ -158,8 +210,25 @@ export function Marcador({ nomes, onGameReset }) {
                             Vez de {jogadores[jogadorAtual].nome}
                         </p>
                         <p className="pontos">
-                            {jogadores[jogadorAtual].pontos.total} pontos
+                            {totalComBonus(jogadores[jogadorAtual].pontos)}{' '}
+                            pontos
                         </p>
+                        {calcularBonus(jogadores[jogadorAtual].pontos) > 0 ? (
+                            <p className="bonus-indicador font-regular">
+                                Bônus +{BONUS_VALOR}
+                            </p>
+                        ) : (
+                            faltaParaBonus(jogadores[jogadorAtual].pontos) !==
+                                null && (
+                                <p className="bonus-indicador bonus-faltando font-regular">
+                                    Faltam{' '}
+                                    {faltaParaBonus(
+                                        jogadores[jogadorAtual].pontos
+                                    )}{' '}
+                                    pts para o bônus
+                                </p>
+                            )
+                        )}
                         <Tabela
                             jogadorAtual={jogadorAtual}
                             jogadores={jogadores}

--- a/src/components/Splash.jsx
+++ b/src/components/Splash.jsx
@@ -5,7 +5,11 @@ import logo from './../assets/logo.png';
 export function Splash({ fechando }) {
     return (
         <div className={`splash ${fechando ? 'splash-fechando' : ''}`}>
-            <img src={logo} alt="Logo Marcador General" className="splash-logo" />
+            <img
+                src={logo}
+                alt="Logo Marcador General"
+                className="splash-logo"
+            />
             <div className="splash-spinner" aria-label="Carregando" />
         </div>
     );

--- a/src/styles/CadastroJogadores.scss
+++ b/src/styles/CadastroJogadores.scss
@@ -55,3 +55,46 @@
         text-align: left;
     }
 }
+
+.modo-jogo {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6em;
+    margin-bottom: 2em;
+    color: $font-white;
+
+    &-titulo {
+        font-size: $font-size;
+    }
+
+    &-opcoes {
+        border: 1px solid $border-color;
+        border-radius: 4px;
+        overflow: hidden;
+    }
+
+    &-botao {
+        padding: 0.6em 1.4em;
+        font-size: $font-size;
+        color: $font-white;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+
+        &.ativo {
+            background: #0092e6;
+            color: #fff;
+        }
+
+        & + & {
+            border-left: 1px solid $border-color;
+        }
+    }
+
+    &-dica {
+        font-size: $font-size - 3px;
+        color: $border-color;
+        text-align: center;
+    }
+}

--- a/src/styles/FimDeJogo.scss
+++ b/src/styles/FimDeJogo.scss
@@ -36,4 +36,9 @@
         font-size: $font-size;
         color: #ccc;
     }
+
+    &-bonus {
+        color: #45d17a;
+        font-size: $font-size - 3px;
+    }
 }

--- a/src/styles/Marcador.scss
+++ b/src/styles/Marcador.scss
@@ -7,6 +7,16 @@
     font-weight: 400;
 }
 
+.bonus-indicador {
+    font-size: 14px;
+    color: #45d17a;
+    margin-top: 0.2em;
+
+    &.bonus-faltando {
+        color: #c9a227;
+    }
+}
+
 .table-holder {
     margin: 0 20px 20px;
 }


### PR DESCRIPTION


Modo de jogo selecionavel no cadastro (toggle Classico | Com bonus):
- no modo 'bonus', 63+ nas categorias numericas (1-6) rende +35 pontos
- o bonus e derivado das categorias (nao armazenado), entao acompanha as jogadas e o 'voltar jogada' automaticamente; total exibido/ranqueado = soma + bonus
- placar mostra indicador dinamico ('Faltam X pts para o bonus' -> 'Bonus +35'); fim de jogo marca quem recebeu o bonus
- dica da regra so aparece quando 'Com bonus' esta selecionado

Fix: impede iniciar partida sozinho (minimo de 2 jogadores) via constantes MIN_JOGADORES/MAX_JOGADORES no cadastro e validacao no handleSalvar.

Docs: README ganha secao 'Modos de jogo'; DOCUMENTATION atualizada (remove itens do roadmap/limitacoes ja resolvidos).